### PR TITLE
Remove fake argument from docstring

### DIFF
--- a/src/etaoin/api.clj
+++ b/src/etaoin/api.clj
@@ -83,8 +83,6 @@
   - `method`: a keyword represents HTTP method, e.g. `:get`, `:post`,
   `:delete`, etc.
 
-  - sdfsdf  `dsfsd`
-
   - `path`: a vector of strings/keywords represents a server's
   path. For example:
 


### PR DESCRIPTION
I just noticed this when I was looking at the docs.