### PR TITLE
Fix get-window-handles for chrome and phantom

### DIFF
--- a/src/etaoin/api.clj
+++ b/src/etaoin/api.clj
@@ -209,7 +209,7 @@
 (defmethods get-window-handles [:chrome :phantom]
   [driver]
   (with-resp driver :get
-    [:session (:session @driver) :window :window_handles]
+    [:session (:session @driver) :window_handles]
     nil resp
     (:value resp)))
 


### PR DESCRIPTION
This command failed with an HTTP error. I've confirmed that this fix works for the recent versions of chromedriver and phantomjs that I have installed.