### PR TITLE
Fix switch-window for chrome

### DIFF
--- a/src/etaoin/api.clj
+++ b/src/etaoin/api.clj
@@ -233,7 +233,7 @@
   [driver handle]
   (with-resp driver :post
     [:session (:session @driver) :window]
-    {:handle handle} _))
+    {:name handle} _))
 
 (defmulti close-window
   "Closes the current browser window."


### PR DESCRIPTION
This was a necessary change for switch-window to work for me with chrome. I wanted to add a test to the test suite to make sure this works for all browsers. But I couldn't get the test suite to run the firefox tests unfortunately. Maybe you can check to see if my change doesn't break firefox or safari, thank you.