### PR TITLE
support for '[text()=xxx]' queries

### DIFF
--- a/resources/html/test.html
+++ b/resources/html/test.html
@@ -96,6 +96,7 @@
             }
         </script>
         <button id="wait-button" onclick="button_wait()">Test</button>
+        <button onclick="button_wait()">Test Wait Button</button>
         <span id="wait-span"></span>
 
         <h3>Wait for has class section</h3>

--- a/src/etaoin/api.clj
+++ b/src/etaoin/api.clj
@@ -450,14 +450,16 @@
   [q]
   (let [tag (or (:tag q) :*)
         idx (:index q)
-        attrs (dissoc q :tag :index)
+        text (:text q)
+        attrs (dissoc q :tag :index :text)
         get-val (fn [val] (if (keyword? val)
                             (name val)
                             (str val)))
         pair (fn [[key val]] (format "[@%s='%s']"
                                      (name key)
                                      (get-val val)))
-        parts (map pair attrs)
+        parts (cond-> (map pair attrs)
+                text (conj (format "[text()='%s']" (get-val text))))
         xpath (apply str ".//" (name tag) parts)
         xpath (str xpath (if idx (format "[%s]" idx) ""))]
     xpath))

--- a/test/etaoin/api_test.clj
+++ b/test/etaoin/api_test.clj
@@ -524,3 +524,10 @@
           (let [files (file-seq (io/file dir-tmp))]
             (is (= (-> files rest count)
                    2))))))))
+
+(deftest test-click-by-text
+  (testing "click on a button by text")
+  (doto *driver*
+    (refresh)
+    (click-visible {:tag :button :text "Test Wait Button"})
+    (wait-has-text :wait-span "-secret-" {:message "wait simiple"})))


### PR DESCRIPTION
Needed to click on tabs and didn't want to add IDs to the links.

Allow to specify `:text` attribute in functions such as `click-visible`.

The test fails on firefox because of the #35, if you comment out `:firefox` in the `fixture-browsers`, the `lein test :only etaoin.api-test/test-click-by-text` should pass.