### PR TITLE
Adds ability to find text with quotes

### DIFF
--- a/resources/html/test.html
+++ b/resources/html/test.html
@@ -185,6 +185,13 @@
             <span>3</span>
         </div>
 
+        <h3>Find text with quote</h3>
+        <div id="find-quote">
+            <div>
+                <b>Text with a 'quote</b>
+            </div>
+        </div>
+
         <h3 id="document-end">Document end</h3>
 
     </body>

--- a/src/etaoin/api.clj
+++ b/src/etaoin/api.clj
@@ -1553,8 +1553,8 @@
    (has-text? driver {:tag :*} text))
   ([driver q text]
    (let [[locator term] (q-expand driver q)
-         term1 (format "%s[contains(text(), '%s')]" term text)
-         term2 (format "%s//*[contains(text(), '%s')]" term text)]
+         term1 (format "%s[contains(text(), \"%s\")]" term text)
+         term2 (format "%s//*[contains(text(), \"%s\")]" term text)]
      (when-not (= locator locator-xpath)
        (throw+ {:type :etaoin/locator
                 :driver @driver

--- a/test/etaoin/api_test.clj
+++ b/test/etaoin/api_test.clj
@@ -524,3 +524,7 @@
           (let [files (file-seq (io/file dir-tmp))]
             (is (= (-> files rest count)
                    2))))))))
+
+(deftest find-quotes-in-text
+  (doto *driver*
+    (-> (has-text? "'quote") is)))


### PR DESCRIPTION
When `#has-text` is used, quotes can't be used because of the use of
single quotes in the xpath query that is created. This commit swaps the
single quotes (') in the query for escaped double quotes (\")

Adds a test case as well