### PR TITLE
Invert scroll-left and scroll-right offset calculation

### DIFF
--- a/src/etaoin/api.clj
+++ b/src/etaoin/api.clj
@@ -1236,7 +1236,7 @@
   "Scrolls the page left by specific number of pixels.
   The `scroll-offset` constant is used when not passed."
   ([driver offset]
-   (scroll-by driver offset 0))
+   (scroll-by driver (- offset) 0))
   ([driver]
    (scroll-left driver scroll-offset)))
 
@@ -1244,7 +1244,7 @@
   "Scrolls the page right by specific number of pixels.
   The `scroll-offset` constant is used when not passed."
   ([driver offset]
-   (scroll-by driver (- offset) 0))
+   (scroll-by driver offset 0))
   ([driver]
    (scroll-right driver scroll-offset)))
 


### PR DESCRIPTION
First of all, thank you for your video. It was very good to see your workflow!

I think that the implementation of `scroll-left` and `scroll-right` is inverted.
Considering that the top-left pixel of the page is 0,0, we increase it going down/right.

WDYT?