### PR TITLE
Fix custom marionette port when `:profile` is specified

### DIFF
--- a/src/etaoin/driver.clj
+++ b/src/etaoin/driver.clj
@@ -158,7 +158,10 @@
   [driver profile]
   (-> driver
       (set-options-args ["-profile" profile])
-      (set-args ["--marionette-port" 2828])))
+      ((fn [driver]
+          (if (some #(= "--marionette-port" %) (get-args driver))
+            driver
+            (set-args driver ["--marionette-port" 2828]))))))
 
 ;;
 ;; window size

--- a/test/etaoin/api_test2.clj
+++ b/test/etaoin/api_test2.clj
@@ -1,0 +1,24 @@
+(ns etaoin.api-test2
+  (:require [etaoin.api :refer :all]
+            [etaoin.proc]
+            [clojure.test :refer :all]))
+
+(deftest test-firefox-driver-args
+  (let [args (atom [])]
+    (with-redefs-fn {#'etaoin.proc/run #(reset! args %)}
+      #(do (testing "No custom args"
+             (-> (create-driver :firefox {:port 1234})
+                 (run-driver {}))
+             (is (= @args
+                    ["geckodriver" "--port" 1234])))
+           (testing "Default `--marionette-port` is assigned when `:profile` is specified"
+             (-> (create-driver :firefox {:port 1234})
+                 (run-driver {:profile "/tmp/firefox-profile/1"}))
+             (is (= @args
+                    ["geckodriver" "--port" 1234 "--marionette-port" 2828])))
+           (testing "Custom `--marionette-port` is assigned when `:profile` is specified"
+             (-> (create-driver :firefox {:port 1234})
+                 (run-driver {:profile "/tmp/firefox-profile/1"
+                              :args-driver ["--marionette-port" 2821]}))
+             (is (= @args
+                    ["geckodriver" "--port" 1234 "--marionette-port" 2821])))))))


### PR DESCRIPTION
- fixes #118