### PR TITLE
README: update brew for chromedriver

### DIFF
--- a/README.md
+++ b/README.md
@@ -1050,7 +1050,7 @@ Install specific drivers you need:
 
 - Geckodriver, a driver for Firefox:
 
-  - `brew install geckodriver` for Mac users
+  - `brew cask install geckodriver` for Mac users
   - or download it from the official [Mozilla site][url-geckodriver-dl].
 
 - Phantom.js browser:


### PR DESCRIPTION
This fixes:

```
Error: No available formula with the name "chromedriver"
It was migrated from homebrew/core to caskroom/cask.
You can access it again by running:
  brew tap caskroom/cask
And then you can install it by running:
  brew cask install chromedriver
```