### PR TITLE
Add support for CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,75 @@
+version: 2
+jobs:
+  build:
+    docker:
+      # This Docker image contains a very old firefox and no geckodriver,
+      # due to Selenium compatibility. Since we don't use Selenium, we take
+      # care of installing a recent firefox and geckodriver (see below).
+      - image: circleci/clojure:lein-2.8.1-browsers
+    steps:
+      - checkout
+      - run:
+          name: Environment information
+          command: |
+            lsb_release --all
+            firefox --version
+            google-chrome --version
+            chromedriver --version
+            phantomjs --version
+      - run:
+          name: Update firefox and install geckodriver
+          command: .circleci/firefox.sh
+
+      # We want to share the results of "lein deps" between runs.
+      # We assume that the maven cache can change only if "project.clj"
+      # changes (see the checksum in the name of the key below).
+      - restore_cache:
+          keys:
+            - m2-{{ checksum "project.clj" }}
+      - run: lein deps
+      - save_cache:
+          key: m2-{{ checksum "project.clj" }}
+          paths:
+            - ~/.m2
+
+      # For better visibility in the build summary page, we use a separate
+      # run step per test file. In this case, we don't want to stop the build
+      # on first failure, so we use the `when` keyword.
+
+      # Note on the ETAOIN_TEST_DRIVERS environment variable:
+      # The only reason we override the logic to select the drivers is due to
+      # the following bug:
+      # When using firefox, at a certain point there is an exception thrown
+      # from the fixture code. clojure.test is not able to withstand this
+      # and just chokes. As such, we split the tests between firefox-only
+      # and everything but firefox to allow to compare them (and see that
+      # the firefox tests report "ran 0 tests" due to the fixture bug)
+
+      - run: lein test etaoin.xpath-test
+
+      - run:
+          name: lein test etaoin.api-test (firefox)
+          when: always
+          environment:
+            ETAOIN_TEST_DRIVERS: "[:firefox]"
+          command: lein test etaoin.api-test
+
+      - run:
+          name: lein test etaoin.api-test (all but firefox)
+          when: always
+          environment:
+            ETAOIN_TEST_DRIVERS: "[:chrome :phantom]"
+          command: lein test etaoin.api-test
+
+      - run:
+          when: always
+          command: lein test etaoin.api-test2
+
+# TODO
+#
+# * Emit test results in XUNIT format so that CircleCI can provide useful
+#   statistics, see
+#   https://circleci.com/docs/2.0/configuration-reference/#store_test_results
+#
+# * (optimization) parallelize the test jobs with CircleCI `workflows`
+#

--- a/.circleci/firefox.sh
+++ b/.circleci/firefox.sh
@@ -1,0 +1,33 @@
+#! /bin/bash
+
+set -o nounset
+set -o errexit
+set -o xtrace
+
+# Remove the firefox that comes with circleci docker image, too old.
+sudo dpkg --purge firefox-mozilla-build
+echo
+
+# The firefox available with APT is still too old (version 52.9), so we need to
+# install manually. We will install as /usr/local/bin/firefox
+FIREFOX_URI="https://download.mozilla.org/?product=firefox-latest&os=linux64&lang=en-US"
+wget --quiet --content-disposition "$FIREFOX_URI"
+# Archive file name is something like firefox-61.0.1.tar.bz2
+sudo tar xf firefox-*.tar.bz2 -C /usr/local
+sudo ln -s /usr/local/firefox/firefox /usr/local/bin/firefox
+which firefox
+firefox --version
+echo
+
+# Adapted from the commented-out dockerfile
+# https://github.com/CircleCI-Public/circleci-dockerfiles/blob/master/clojure/images/lein-2.8.1/browsers/Dockerfile
+
+GECKODRIVER_META="https://api.github.com/repos/mozilla/geckodriver/releases/latest"
+GECKODRIVER_LATEST_RELEASE_URL=$(curl $GECKODRIVER_META | jq -r ".assets[] | select(.name | test(\"linux64\")) | .browser_download_url")
+curl --silent --show-error --location --fail --retry 3 --output /tmp/geckodriver_linux64.tar.gz "$GECKODRIVER_LATEST_RELEASE_URL"
+cd /tmp
+tar xf geckodriver_linux64.tar.gz
+chmod +x geckodriver 
+sudo mv geckodriver /usr/local/bin/
+which geckodriver
+geckodriver --version

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ autodoc/**
 node_modules
 package-lock.json
 TAGS
+*.iml

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 # Etaoin
 
+[![CircleCI](https://circleci.com/gh/marco-m/etaoin.svg?style=svg)](https://circleci.com/gh/marco-m/etaoin)
+
 Pure Clojure implementation of [Webdriver][url-webdriver] protocol. Use that
 library to automate a browser, test your frontend behaviour, simulate human
 actions or whatever you want.


### PR DESCRIPTION
hello,

thanks for Etaoin! This fixes #158

ETAOIN MAINTAINERS: TODO BEFORE MERGING:

- create project on circleci
- enable building for PR
- update README.md to point to the correct etaoin on circleci :-)
- consider setting the default value for logging to INFO as opposed to DEBUG. All the debug logging just hides the failing tests in my opinion

DETAILS OF COMMIT:

- Select the drivers based on the OS (previously it was attempting
  to run Safari on Linux)
- Add .circleci/config.yml configuration file
- Add optional ETAOIN_TEST_DRIVERS environment variable:
  By default we run the tests with all the drivers supported on the
  current OS. To override this, you can set the environment variable
  ETAOIN_TEST_DRIVERS to a Clojure vector encoded as a string; for
  example:

    ETAOIN_TEST_DRIVERS="[:firefox]" lein test

  There are two use cases for this overriding mechanism:
  1. run with only one driver to pinpoint specific problems
  2. (temporary) allow to split the test runs on CI between firefox
     and all but firefox. Why? Because with firefox there is a bug
     that throws an exception inside the test fixture, this chokes
     clojure.test and wrongly reports "ran 0 tests". To allow to show
     that this bug is ONLY for firefox, we separate the test runs
     (see explanation in .circleci/config.yml)

