### PR TITLE
Collect test run information on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,25 +45,29 @@ jobs:
       # and everything but firefox to allow to compare them (and see that
       # the firefox tests report "ran 0 tests" due to the fixture bug)
 
-      - run: lein test etaoin.xpath-test
+      - run: lein test2junit etaoin.xpath-test
 
       - run:
-          name: lein test etaoin.api-test (firefox)
+          name: lein test2junit etaoin.api-test (firefox)
           when: always
           environment:
             ETAOIN_TEST_DRIVERS: "[:firefox]"
-          command: lein test etaoin.api-test
+          command: lein test2junit etaoin.api-test
 
       - run:
-          name: lein test etaoin.api-test (all but firefox)
+          name: lein test2junit etaoin.api-test (all but firefox)
           when: always
           environment:
             ETAOIN_TEST_DRIVERS: "[:chrome :phantom]"
-          command: lein test etaoin.api-test
+          command: lein test2junit etaoin.api-test
 
       - run:
           when: always
-          command: lein test etaoin.api-test2
+          command: lein test2junit etaoin.api-test2
+
+      - store_test_results:
+          path: target/test2junit
+
 
 # TODO
 #

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ node_modules
 package-lock.json
 TAGS
 *.iml
+build.xml

--- a/project.clj
+++ b/project.clj
@@ -17,6 +17,11 @@
                  [org.clojure/tools.logging "0.3.1"]
                  [org.clojure/data.codec "0.1.0"]]
 
+  ; When running the tests as `lein test2junit`, emit XUNIT test reports to enable CircleCI
+  ; to collect statistics over time
+  :plugins [[test2junit "1.1.2"]]
+  :test2junit-output-dir "target/test2junit"
+
   :autodoc {:name "Etaoin"
             :page-title "Etaoin API Documentation"
             :description "Pure Clojure Webdriver protocol implementation."


### PR DESCRIPTION
When running the tests on CicleCI, emit XUNIT test reports so
that CircleCI call collect and show test statistics.

Tests statistics are shown in two places:

1. Each single build gives an overview of the failing tests. Compare:

- with overview: https://circleci.com/gh/marco-m/etaoin/47
- without overview: https://circleci.com/gh/igrishaev/etaoin/3

2. The build-insights page. Compare:

- with test insights: https://circleci.com/build-insights/gh/marco-m/etaoin/circleci-xunit
- without test insights: https://circleci.com/build-insights/gh/igrishaev/etaoin/master

