### PR TITLE
Update README.md and add inner HTML getter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1103,14 +1103,14 @@ Install specific drivers you need:
 
 - Google [Chrome driver][url-chromedriver]:
 
-  - `brew install chromedriver` for Mac users
+  - `brew cask install chromedriver` for Mac users
   - or download compiled binaries from the [official site][url-chromedriver-dl].
   - ensure you have at least `2.28` version installed. `2.27` and below has a
     bug related to maximizing a window (see [[Troubleshooting]]).
 
 - Geckodriver, a driver for Firefox:
 
-  - `brew cask install geckodriver` for Mac users
+  - `brew install geckodriver` for Mac users
   - or download it from the official [Mozilla site][url-geckodriver-dl].
 
 - Phantom.js browser:

--- a/src/etaoin/api.clj
+++ b/src/etaoin/api.clj
@@ -882,6 +882,26 @@
        (get-element-css-el driver el prop)))))
 
 ;;
+;; element inner HTML
+;;
+
+(defn get-element-inner-html-el
+  "Returns element's inner text by its identifier."
+  [driver el]
+  (:value (execute {:driver driver
+                    :method :get
+                    :path [:session (:session @driver) :element el :property :innerHTML]})))
+
+(defn get-element-inner-html
+  "Returns element's inner HTML.
+
+  For element `el` in `<div id=\"el\"><p class=\"foo\">hello</p></div>` it will
+  be \"<p class=\"foo\">hello</p>\" string.
+"
+  [driver q]
+  (get-element-inner-html-el driver (query driver q)))
+
+;;
 ;; element text, name and value
 ;;
 


### PR DESCRIPTION
Thanks a lot for this wonderful work! I've skimmed the source code and it's been a pleasure to read. At first I was afraid I couldn't tweak it to use a custom browser but actually your code is written with style and extensible so it's as easy as

``` clj
(def firefox-developer-edition-driver
  (firefox {:path-browser "/Applications/Firefox Developer Edition.app/Contents/MacOS/firefox"}))
```

Anyway, back to topic! ^^ Actually this small PR intends to fix two things:
- `geckodriver` is currently not a cask but `chromedriver` is.
- Provide access to raw inner HTML, for example to use etaoin in conjunction with [enlive](https://github.com/cgrand/enlive) – or any better ideas for that?

Let me know if there's anything I could do to ease the review / approval process.