### PR TITLE
Fix for "Connection reset by peer"

### DIFF
--- a/src/etaoin/api.clj
+++ b/src/etaoin/api.clj
@@ -133,9 +133,17 @@
 
 (defn delete-session [driver]
   "Deletes a session. Closes a browser window."
-  (execute {:driver driver
-            :method :delete
-            :path [:session (:session @driver)]}))
+  (try+
+    (execute {:driver driver
+              :method :delete
+              :path [:session (:session @driver)]})
+    (catch [:type :etaoin/http-error] {:keys [status response]}
+      (if (and (= status 404)
+               (= (-> response :value :error) "invalid session id"))
+        (log/debug "Attempted to close driver session. Session has already been deleted")
+        (throw+)))
+    (finally driver)))
+
 
 ;;
 ;; active element

--- a/src/etaoin/api.clj
+++ b/src/etaoin/api.clj
@@ -32,8 +32,8 @@
             [cheshire.core :refer [generate-stream]]
             [slingshot.slingshot :refer [try+ throw+]])
   (:import java.util.Date
-           java.net.ConnectException
-           java.text.SimpleDateFormat))
+           java.text.SimpleDateFormat
+           (java.io IOException)))
 
 ;;
 ;; defaults
@@ -1542,11 +1542,11 @@
 (defn connectable?
   "Checks whether it's possible to connect a given host/port pair."
   [host port]
-  (with-exception ConnectException false
+  (with-exception IOException false
     (let [socket (java.net.Socket. ^String host ^int port)]
       (if (.isConnected socket)
         (do
-          (.close socket)
+          (try (.close socket) (catch IOException _))
           true)
         false))))
 

--- a/src/etaoin/api.clj
+++ b/src/etaoin/api.clj
@@ -260,7 +260,8 @@
   [driver]
   (-> (execute {:driver driver
                 :method :get
-                :path [:session (:session @driver) :window :size]})
+                :path [:session (:session @driver) :window :rect]})
+      :value
       (select-keys [:width :height])))
 
 (defmethod get-window-size :default
@@ -282,7 +283,8 @@
   [driver]
   (-> (execute {:driver driver
                 :method :get
-                :path [:session (:session @driver) :window :position]})
+                :path [:session (:session @driver) :window :rect]})
+      :value
       (select-keys [:x :y])))
 
 (defmethod get-window-position :default
@@ -707,6 +709,7 @@
   (-> (execute {:driver driver
                 :method :get
                 :path [:session (:session @driver) :element el :rect]})
+      :value
       (select-keys [:x :y])))
 
 (defn get-element-location [driver q]

--- a/test/etaoin/api_test.clj
+++ b/test/etaoin/api_test.clj
@@ -383,14 +383,12 @@
                          :value "test1",
                          :path "/",
                          :domain "",
-                         :expiry nil,
                          :secure false,
                          :httpOnly false}
                         {:name "cookie2",
                          :value "test2",
                          :path "/",
                          :domain "",
-                         :expiry nil,
                          :secure false,
                          :httpOnly false}])))
       (when-phantom *driver*
@@ -425,7 +423,6 @@
                 :value "test2"
                 :path "/"
                 :domain ""
-                :expiry nil
                 :secure false
                 :httpOnly false})))
       (when-phantom *driver*

--- a/test/etaoin/api_test.clj
+++ b/test/etaoin/api_test.clj
@@ -256,10 +256,10 @@
      (catch [:type :etaoin/timeout] data
        (is (= (-> data (dissoc :predicate :time-rest))
               {:type :etaoin/timeout
-               :message "No -secret- text on the page"
+               :message "Wait for :wait-span element has text -secret-"
                :timeout 1
-               :interval 0.1
-               :times 11})))))
+               :interval 0.33
+               :times 4})))))
   (testing "wait for non-existing text"
     (doto *driver*
       (refresh)
@@ -274,10 +274,10 @@
      (catch [:type :etaoin/timeout] data
        (is (= (-> data (dissoc :predicate :time-rest))
               {:type :etaoin/timeout
-               :message "wait non-existing"
+               :message "Wait for :wait-span element has text -dunno-whatever-foo-bar-"
                :timeout 2
-               :interval 0.1
-               :times 20}))))))
+               :interval 0.33
+               :times 7}))))))
 
 (deftest test-wait-has-class
   (is 1)

--- a/test/etaoin/api_test.clj
+++ b/test/etaoin/api_test.clj
@@ -298,7 +298,7 @@
 
 (deftest test-drag-n-drop
   (is 1)
-  (let [url "http://marcojakob.github.io/dart-dnd/basic/web/"
+  (let [url "http://marcojakob.github.io/dart-dnd/basic/"
         doc {:class :document}
         trash {:xpath "//div[contains(@class, 'trash')]"}]
     (when-not (or (firefox? *driver*)

--- a/test/etaoin/api_test.clj
+++ b/test/etaoin/api_test.clj
@@ -556,9 +556,10 @@
         (is false "should be caught")
         (catch Exception e
           (is true "caught")
-          (let [files (file-seq (io/file dir-tmp))]
+          (let [files (file-seq (io/file dir-tmp))
+                expected-file-count (if (supports-logs? *driver*) 3 2)]
             (is (= (-> files rest count)
-                   2))))))))
+                   expected-file-count))))))))
 
 (deftest test-find-quotes-in-text
   (doto *driver*

--- a/test/etaoin/api_test.clj
+++ b/test/etaoin/api_test.clj
@@ -436,24 +436,6 @@
                 :path "/"
                 :secure false
                 :value "test2"})))))
-  (testing "setting a cookie"
-    (when-not (or (phantom? *driver*)
-                  (safari? *driver*))
-      (set-cookie *driver* {:httponly false
-                            :name "cookie3"
-                            :domain ""
-                            :secure false
-                            :value "test3"})
-      (when-firefox *driver*
-        (let [cookie (get-cookie *driver* :cookie3)]
-          (is (= cookie)
-              {:name "cookie3"
-               :value "test3"
-               :path ""
-               :domain ""
-               :expiry nil
-               :secure false
-               :httpOnly false})))))
   (testing "deleting a cookie"
     (when-not-phantom
         *driver*


### PR DESCRIPTION
This is a proposed fix for issue #165.

When running my own UI tests using the Etaoin library on a Linux CI server, my tests seem to fail 30% of the time with a `java.net.SocketException: Connection reset by peer` error.

I have applied this patch to a private repo version of Etaoin and I am no longer seeing failures in my UI tests.