### PR TITLE
Fix "Connection reset by peer"

### DIFF
--- a/src/etaoin/api.clj
+++ b/src/etaoin/api.clj
@@ -32,8 +32,8 @@
             [cheshire.core :refer [generate-stream]]
             [slingshot.slingshot :refer [try+ throw+]])
   (:import java.util.Date
-           java.net.ConnectException
-           java.text.SimpleDateFormat))
+           java.text.SimpleDateFormat
+           (java.io IOException)))
 
 ;;
 ;; defaults
@@ -1531,11 +1531,11 @@
 (defn connectable?
   "Checks whether it's possible to connect a given host/port pair."
   [host port]
-  (with-exception ConnectException false
+  (with-exception IOException false
     (let [socket (java.net.Socket. ^String host ^int port)]
       (if (.isConnected socket)
         (do
-          (.close socket)
+          (try (.close socket) (catch IOException _))
           true)
         false))))
 


### PR DESCRIPTION
This is a proposed fix for issue #165.

When running my own UI tests using the Etaoin library on a Linux CI server, my tests seem to fail 30% of the time with a `java.net.SocketException: Connection reset by peer` error.

I have applied this patch to a private repo version of Etaoin and I am no longer seeing failures in my UI tests.

It is possible for an exception to be thrown when calling `close` if data is still being transferred, so I have caught the exception there as well as during `connect`, even though we don't care about the "error on close" message itself.