### PR TITLE
Fix typo in absent? docstring

### DIFF
--- a/src/etaoin/api.clj
+++ b/src/etaoin/api.clj
@@ -1607,7 +1607,7 @@
     (get-element-text driver q)
     true))
 
-(def ^{:doc "Oppsite to `exists?`."}
+(def ^{:doc "Opposite of `exists?`."}
   absent? (complement exists?))
 
 (defmulti displayed-el?


### PR DESCRIPTION
Hi. I Just spotted a small error in the docstring.