### PR TITLE
Use 24-hour date format in postmortem-handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -522,7 +522,7 @@ absent.
  :dir-log "/home/ivan/UI-tests/console"
 
  ;; a string template to format a date; See SimpleDateFormat Java class
- :date-format "yyyy-MM-dd-hh-mm-ss"}
+ :date-format "yyyy-MM-dd-HH-mm-ss"}
 ```
 
 ## Reading browser's logs

--- a/src/etaoin/api.clj
+++ b/src/etaoin/api.clj
@@ -2404,7 +2404,7 @@
 
         file-tpl "%s-%s-%s-%s.%s"
 
-        date-format (or date-format "yyyy-MM-dd-hh-mm-ss")
+        date-format (or date-format "yyyy-MM-dd-HH-mm-ss")
         params [(-> @driver :type name)
                 (-> @driver :host)
                 (-> @driver :port)
@@ -2457,7 +2457,7 @@
   files with console logs. If `nil`, `:dir` value is used.
 
   -- `:date-format`: a string represents date(time) pattern to make
-  filenames unique. Default is \"yyyy-MM-dd-hh-mm-ss\". See Oracle
+  filenames unique. Default is \"yyyy-MM-dd-HH-mm-ss\". See Oracle
   Java `SimpleDateFormat` class manual for more patterns."
   [driver opt & body]
   `(try


### PR DESCRIPTION
Currently in `etaoin.api/postmortem-handler` the default `date-format` is `"yyyy-MM-dd-hh-mm-ss"`, but lowercase `hh` stands for [Hour in am/pm (1-12)](https://docs.oracle.com/javase/7/docs/api/java/text/SimpleDateFormat.html). Since there is no am/pm marker in the pattern, it was most probably meant to be in 24 hour format which is `HH`. This PR fixes that.