### PR TITLE
Add `screenshot-element` support for chrome driver.

### DIFF
--- a/README.md
+++ b/README.md
@@ -460,8 +460,8 @@ A native Java File object is also supported:
 
 ### Screening elements
 
-With Firefox, you may capture not the whole page but a single element, say a
-div, an input widget or whatever. It doesn't work with other browsers for
+With Firefox and Chrome, you may capture not the whole page but a single element,
+say a div, an input widget or whatever. It doesn't work with other browsers for
 now. Example:
 
 ```clojure

--- a/src/etaoin/api.clj
+++ b/src/etaoin/api.clj
@@ -2447,8 +2447,8 @@
   [driver q file]
   (util/error "This driver doesn't support screening elements."))
 
-(defmethod screenshot-element
-  :firefox
+(defmethods screenshot-element
+  [:chrome :firefox]
   [driver q file]
   (let [el (query driver q)
         resp (execute {:driver driver


### PR DESCRIPTION
* Support for screenshots of elements seems to have been added since ChromeDriver 2.42.   
* Tested successfully with ChromeDriver 74.0.3729.6 from [this test](https://github.com/quil/quil/blob/master/test/clj/quil/snippet.clj#L145).