### PR TITLE
[WIP] Issue #162 - exception in fixture code is causing other test failures…

### DIFF
--- a/src/etaoin/api.clj
+++ b/src/etaoin/api.clj
@@ -2755,10 +2755,16 @@
 (defn disconnect-driver
   "Disconnects from a running Webdriver server.
 
-  Closes the current session that is stored in the driver. Removes the
-  session from the driver instance. Returns modified driver."
+  Closes the current session that is stored in the driver if it still exists.
+  Removes the session from the driver instance. Returns modified driver."
   [driver]
-  (delete-session driver)
+
+  (try (delete-session driver)
+       (catch Exception e
+         (if (not (= 404 (:status (ex-data e))))
+           ;; the exception was caused by something other than "session not found"
+           (throw e))))
+  
   (swap! driver dissoc
          :session :capabilities)
   driver)


### PR DESCRIPTION
… to be hidden. Problem occurs when delete-session is called by with-driver after the session is already gone (in this case, close-window).

Are you OK with this approach (checking for 404 in disconnect-driver)?